### PR TITLE
HttpClient pool

### DIFF
--- a/.idea/greenchoice-variable-tariffs.iml
+++ b/.idea/greenchoice-variable-tariffs.iml
@@ -2,6 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.8 (greenchoice-variable-tariffs)" jdkType="Python SDK" />

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "3.8"
+
+install: "pip install -r requirements.test.txt"
+
+script:
+  - pytest
+  
+after_success:
+  - codecov

--- a/custom_components/greenchoice_variable_tariffs/manifest.json
+++ b/custom_components/greenchoice_variable_tariffs/manifest.json
@@ -3,6 +3,7 @@
   "config_flow": false,
   "dependencies": [],
   "documentation": "https://github.com/toaomatis/greenchoice-variable-tariffs",
+  "issue_tracker": "https://github.com/toaomatis/greenchoice-variable-tariffs/issues",
   "domain": "greenchoice_variable_tariffs",
   "iot_class": "cloud_polling",
   "name": "Greenchoice Variable Tariffs Sensor",

--- a/custom_components/greenchoice_variable_tariffs/sensor.py
+++ b/custom_components/greenchoice_variable_tariffs/sensor.py
@@ -15,7 +15,8 @@ from homeassistant.const import (
     CURRENCY_EURO,
     DEVICE_CLASS_MONETARY,
     ENERGY_KILO_WATT_HOUR,
-    STATE_UNKNOWN
+    STATE_UNKNOWN,
+    VOLUME_CUBIC_METERS
 )
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -281,5 +282,5 @@ class GreenchoiceEnergySensor(Entity):
         if self._measurement_type == SENSOR_TYPE_GAS_TARIFF:
             self._icon = 'mdi:fire'
             self._name = SENSOR_TYPE_GAS_TARIFF
-            self._unit_of_measurement = f'{CURRENCY_EURO}/{ENERGY_KILO_WATT_HOUR}'
+            self._unit_of_measurement = f'{CURRENCY_EURO}/{VOLUME_CUBIC_METERS}'
         _LOGGER.debug(f'Sensor Updated {self=}')

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov==2.9.0
 pytest-homeassistant-custom-component
+codecov

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,4 +1,4 @@
 pytest
-pytest-cov==2.9.0
+pytest-cov
 pytest-homeassistant-custom-component
 codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,9 @@ show_missing = true
 testpaths = tests
 norecursedirs = .git
 addopts =
-    --strict
+    --strict-markers
     --cov=custom_components
+    --cov-report=xml
 
 [flake8]
 # https://github.com/ambv/black#line-length

--- a/tests/test_greenchoice_api.py
+++ b/tests/test_greenchoice_api.py
@@ -1,8 +1,8 @@
 """Test component setup."""
 import json
-import os
 
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import load_fixture
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
 from custom_components.greenchoice_variable_tariffs.const import (
@@ -17,12 +17,12 @@ from tests.const import MOCK_CONFIG
 
 async def test_greenchoice_api(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, skip_setup: bool = False, ):
     """Test Greenchoice API."""
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    with open(f'{dir_path}/fixtures/01_response.json') as f:
-        response_dict = json.load(f)
+    response_dict = json.loads(load_fixture('01_response.json'))
 
-    aioclient_mock.get('https://www.greenchoice.nl/umbraco/surface/quotation/GetQuotation', json=response_dict)
-    api = GreenchoiceApiData(**MOCK_CONFIG)
+    aioclient_mock.get('https://www.greenchoice.nl/umbraco/surface/quotation/GetQuotation',
+                       json=response_dict,
+                       headers={"Content-Type": "application/json"}, )
+    api = GreenchoiceApiData(hass, **MOCK_CONFIG)
 
     await api.async_update()
     result = api.result

--- a/tests/test_greenchoice_api.py
+++ b/tests/test_greenchoice_api.py
@@ -30,3 +30,6 @@ async def test_greenchoice_api(hass: HomeAssistant, aioclient_mock: AiohttpClien
     assert SENSOR_TYPE_LOW_TARIFF in result
     assert SENSOR_TYPE_GAS_TARIFF in result
     assert SENSOR_MEASUREMENT_DATE in result
+    assert result[SENSOR_TYPE_NORMAL_TARIFF] == 0.5367
+    assert result[SENSOR_TYPE_LOW_TARIFF] == 0.4136
+    assert result[SENSOR_TYPE_GAS_TARIFF] == 2.0485

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,9 @@
 """Test component setup."""
+from homeassistant.core import HomeAssistant
+
 from custom_components.greenchoice_variable_tariffs import async_setup
 
 
-async def test_async_setup(hass):
+async def test_async_setup(hass: HomeAssistant):
     """Test the component gets setup."""
     assert await async_setup(hass, {}) is True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,12 +1,12 @@
 """Test component setup."""
+from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.greenchoice_variable_tariffs import async_setup
 from custom_components.greenchoice_variable_tariffs.const import DOMAIN
 from tests.const import MOCK_CONFIG
 
 
-async def test_async_setup(hass):
+async def test_async_setup(hass: HomeAssistant):
     """Test the component gets setup."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG)
     entry.add_to_hass(hass)


### PR DESCRIPTION
(re)use HASS own HttpClient pool instead of creating a new one every request